### PR TITLE
Stop Sublime from opening all browsers on OSX for invalid tokens containing '\'

### DIFF
--- a/goto_documentation.py
+++ b/goto_documentation.py
@@ -126,6 +126,7 @@ class GotoDocumentationCommand(sublime_plugin.TextCommand):
             if (tscope in substitue_map and query in substitue_map[tscope]):
                 query = substitue_map[tscope][query]
 
+            query = query.replace("\\", "") # backslash causes Sublime on OSX to open all available browsers
             if ("DotQ" in query):
                 tscope = "Q"
             if ("Dotz" in query):


### PR DESCRIPTION
* using the plugin's goto documentation (`F1`) on a Q token containing `\` that isn't contained in the substitute map causes Sublime to open all available browsers on OSX