### PR TITLE
fix bug where large number result causes q to crash with 'wsfull

### DIFF
--- a/q_send.py
+++ b/q_send.py
@@ -44,7 +44,7 @@ class QSendRawCommand(q_chain.QChainCommand):
            
             post_exec = []
             #get exec time, result dimensions
-            post_exec.append('res:`time`c`mem!((3_string `second$.st.execTime:.z.T-.st.start);(" x " sv string (count @[cols;.st.tmp;()]),count .st.tmp); ((@[{.Q.w[][`used]}; (); 0]) - .st.mem))')
+            post_exec.append('res:`time`c`mem!((3_string `second$.st.execTime:.z.T-.st.start);(" x " sv string (count @[{$[0<=type x; cols x;()]};.st.tmp;()]),count .st.tmp); ((@[{.Q.w[][`used]}; (); 0]) - .st.mem))')
             post_exec.append('delete tmp, start, execTime from `.st') #clean up .st
             #post_exec.append('.st: ` _ .st') #clean up .st
             post_exec.append('res')


### PR DESCRIPTION
https://github.com/komsit37/sublime-q/issues/17
This is caused by my custom q code wrapper which tries to figure out table dimension from the result.
In short, it tries to to execute 'cols 60000000000' and got 'wsfull'.
The fix is to NOT call 'cols' on atom types (type < 0) (doing this will raise error anyway)