### PR TITLE
Support send and async send to read-only kdb instances

### DIFF
--- a/q_send_async.py
+++ b/q_send_async.py
@@ -22,7 +22,7 @@ class QSendAsyncCommand(sublime_plugin.TextCommand):
       #print(s)
       if (s[0] == "\\"):
         s = "value\"\\" + s + "\""
-      s = ".Q.s .st.tmp:" + s  #save to temprary result, so we can get dimension later
+      s = ".Q.s " + s
 
       res = q_send.QSendRawCommand.sendAndUpdateStatus(self.view, con, s)
       if output:


### PR DESCRIPTION
Sublime currently attempts to save the result of the last input to .st.tmp, as well as using other saved helpers such as memory status (.st.mem) and start time (.st.start). The latter two can be handled just as well on the client side (in python), and the former is now made optional, thus allowing connections to be made to kdb instances where write access (i.e. creating variables in-memory) is not available. This allows sublime-q to be used with kdb processes in multithreaded input mode (negative port servers). Sublime-q is also made more efficient by reducing the number of calls made to kdb each time. 