### PR TITLE
Update to qPython 2.0 and add support for utf-8

### DIFF
--- a/QCon.py
+++ b/QCon.py
@@ -15,7 +15,7 @@ class QCon():
         self.port = port
         self.username = username
         self.password = password
-        self.q = qconnection.QConnection(host = self.host, port = self.getPort(), username = self.username, password = self.password)
+        self.q = qconnection.QConnection(host = self.host, port = self.getPort(), username = self.username, password = self.password, encoding = 'UTF-8')
 
     @classmethod
     def fromH(cls, h):

--- a/qpython/__init__.py
+++ b/qpython/__init__.py
@@ -17,7 +17,7 @@
 __all__ = ['qconnection', 'qtype', 'qtemporal', 'qcollection']
 
 
-__version__ = '1.1.0'
+__version__ = '2.0.0'
 
 
 

--- a/qpython/qreader.py
+++ b/qpython/qreader.py
@@ -99,28 +99,21 @@ class QReader(object):
     
     :Parameters:
      - `stream` (`file object` or `None`) - data input stream
+     - `encoding` (`string`) - encoding for characters parsing
+
+    :Attrbutes:
+     - `_reader_map` - stores mapping between q types and functions
+       responsible for parsing into Python objects
     '''
 
     _reader_map = {}
     parse = Mapper(_reader_map)
 
 
-    def __new__(cls, *args, **kwargs):
-        if cls is QReader:
-            # try to load optional pandas binding
-            try:
-                from qpython._pandas import PandasQReader
-                return super(QReader, cls).__new__(PandasQReader)
-            except ImportError:
-                return super(QReader, cls).__new__(QReader)
-        else:
-            #return super(QReader, cls).__new__(cls)
-            return super().__new__(cls) #komsit fix
-
-
-    def __init__(self, stream):
+    def __init__(self, stream, encoding = 'latin-1'):
         self._stream = stream
         self._buffer = QReader.BytesBuffer()
+        self._encoding = encoding
 
 
     def read(self, source = None, **options):
@@ -207,7 +200,7 @@ class QReader(object):
             uncompressed_size = -8 + self._buffer.get_int()
             compressed_data = self._read_bytes(message_size - 12) if self._stream else self._buffer.raw(message_size - 12)
 
-            raw_data = numpy.fromstring(compressed_data, dtype = numpy.uint8)
+            raw_data = numpy.frombuffer(compressed_data, dtype = numpy.uint8)
             if  uncompressed_size <= 0:
                 raise QReaderException('Error while data decompression.')
 
@@ -226,7 +219,7 @@ class QReader(object):
     def _read_object(self):
         qtype = self._buffer.get_byte()
 
-        reader = QReader._reader_map.get(qtype, None)
+        reader = self._get_reader(qtype)
 
         if reader:
             return reader(self, qtype)
@@ -236,6 +229,10 @@ class QReader(object):
             return self._read_atom(qtype)
 
         raise QReaderException('Unable to deserialize q type: %s' % hex(qtype))
+
+
+    def _get_reader(self, qtype):
+        return self._reader_map.get(qtype, None)
 
 
     @parse(QERROR)
@@ -257,7 +254,7 @@ class QReader(object):
 
     @parse(QCHAR)
     def _read_char(self, qtype = QCHAR):
-        return chr(self._read_atom(QCHAR)).encode('latin-1') 
+        return chr(self._read_atom(QCHAR)).encode(self._encoding)
 
 
     @parse(QGUID)
@@ -299,7 +296,7 @@ class QReader(object):
             return qlist(data, qtype = qtype, adjust_dtype = False)
         elif conversion:
             raw = self._buffer.raw(length * ATOM_SIZE[qtype])
-            data = numpy.fromstring(raw, dtype = conversion)
+            data = numpy.frombuffer(raw, dtype = conversion)
             if not self._is_native:
                 data.byteswap(True)
 

--- a/qpython/qtype.py
+++ b/qpython/qtype.py
@@ -259,8 +259,8 @@ _QNULL1 = numpy.int8(-2**7)
 _QNULL2 = numpy.int16(-2**15)
 _QNULL4 = numpy.int32(-2**31)
 _QNULL8 = numpy.int64(-2**63)
-_QNAN32 = numpy.fromstring(b'\x00\x00\xc0\x7f', dtype=numpy.float32)[0]
-_QNAN64 = numpy.fromstring(b'\x00\x00\x00\x00\x00\x00\xf8\x7f', dtype=numpy.float64)[0]
+_QNAN32 = numpy.frombuffer(b'\x00\x00\xc0\x7f', dtype=numpy.float32)[0]
+_QNAN64 = numpy.frombuffer(b'\x00\x00\x00\x00\x00\x00\xf8\x7f', dtype=numpy.float64)[0]
 _QNULL_BOOL = numpy.bool_(False)
 _QNULL_SYM = numpy.string_('')
 _QNULL_GUID = uuid.UUID('00000000-0000-0000-0000-000000000000')


### PR DESCRIPTION
This change is focused on updating to qPython 2.0. All code changes below should just be either:
1. Diffs from current qPython to 2.0;
2. Add `encoding = 'UTF-8'` to the qconnection init; and
3. Patch `_write_string` to support properly encoding strings to send to kdb. Check out the PR against the qPython repo here: https://github.com/exxeleron/qPython/pull/77

Although this is hopefully straightforward, I recommend testing it for a while before merging since it is such a core part of sublime-q.

Also, a couple things that are NOT changed (yet?):
A. Did not change decoding of the strings in sublime-q, so if you send "õ" you get back "\303\265" (this is how kdb does it, but we could parse it back to "õ" if we wanted).
B. I noticed a small warning, 
`myLocale=locale.setlocale(category=locale.LC_ALL, locale="en_GB.UTF-8");`
`File "./python3.3/locale.py", line 573, in setlocale`
`locale.Error: unsupported locale setting`
I believe that since locale is an optional arg, it should just be `myLocale=locale.setlocale(category=locale.LC_ALL)` but have not included that change here.