### PR TITLE
Allow python to use default locale instead of requiring GB

### DIFF
--- a/q_routine.py
+++ b/q_routine.py
@@ -12,7 +12,11 @@ from socket import error as socket_error
 
 #fix unicode encoding issue when rendering template with non-ascii string
 #see https://stackoverflow.com/questions/9942594/unicodeencodeerror-ascii-codec-cant-encode-character-u-xa0-in-position-20
-import os; import locale; os.environ["PYTHONIOENCODING"] = "utf-8"; myLocale=locale.setlocale(category=locale.LC_ALL, locale="en_GB.UTF-8");
+import os;
+import locale;
+
+os.environ["PYTHONIOENCODING"] = "utf-8";
+myLocale=locale.setlocale(category=locale.LC_ALL, locale="");
 
 #copy code from https://github.com/nickjj/sublime-text-3-packages/blob/master/Packages/Gutter%20Color/gutter_color.py
 def clear_and_reload_cache(force = False):


### PR DESCRIPTION
myLocale=locale.setlocale(category=locale.LC_ALL, locale="en_GB.UTF-8")

This fails on my (windows7/10) machines due to missing the locale "en_GB.UTF-8". This prevents this script (q_routine.py) from running, and ultimately blocks all the chart/graph functionality of sublime-q (i.e. pressing f4 does nothing).

I think the correct workaround is to just use locale="" as this should allow Python to use a default locale on the machine. This works on my US Windows/MacOS machines, but please do try on some on your end to confirm!

As an alternative, we could also wrap setlocale in a try/except block. I do not think it should be necessary for users to have en_GB locale installed. Let me know what you think. 

Thanks.