### PR TITLE
Update qtype.py with numpy.bool

### DIFF
--- a/qpython/qtype.py
+++ b/qpython/qtype.py
@@ -93,6 +93,9 @@ from functools import reduce
 if sys.version > '3':
     long = int
 
+if not hasattr(numpy, "bool"):
+    numpy.bool = numpy.bool_
+
 # qtype constants:
 QNULL               =  0x65
 QGENERAL_LIST       =  0x00


### PR DESCRIPTION
Adds support for numpy >= 1.20

This should be a safe change and allow the usage of more recent versions of numpy.

Recent versions of Sublime allow usage of python 3.8 (instead of 3.3 currently). This change would prepare for that migration -- because python 3.8 would allow (require) later versions of numpy, which, without this change, would be imcompatible with qpython.

I will plan to later submit a PR moving to python 3.8 if no objections. I believe the only step necessary is to add file .python-version with content "3.8" (see https://www.sublimetext.com/docs/api_environments.html)

I tested a fresh install of ST4 and sublime-q on Win 11 using python 3.8 and it worked great, including installing numpy automatically, but some further testing would be good.